### PR TITLE
Fixed adding flows and renaming filenames

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,3 +24,12 @@ History
 ------------------
 
 * Added a shorthand notation to call the program from the command line
+
+0.0.4 (2019-08-04)
+------------------
+
+* A workspace can only be created within the declared workspace directory specified within the config file
+* Files can only be renamed within the baseflow directory
+* Only changed files names are listed in the output 
+* Only missing project flows are getting added when renaming files
+* Added command to check the script version

--- a/picturebot/__init__.py
+++ b/picturebot/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Tomek Joostens"""
 __email__ = 'joostenstomek@gmail.com'
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/picturebot/cli.py
+++ b/picturebot/cli.py
@@ -1,26 +1,56 @@
 """Console script for picturebot."""
+
 import sys
 import os
 import json
 import click
+import picturebot as pb
 import picturebot.helper as helper
 import generalutils.guard as grd
 
-
 def Location(path):
+    '''Config file location method
+    
+    Args:
+        path (string): Path to the config file
+    '''
+
     click.echo(f'Config file location: {path}')
 
 def Create(config):
-#     #Check whether the workplace folder exists    
+    '''Setup the workspace method
+    
+    Args:
+        config (Config): Config data object
+    '''
+
+    # Get the current working directory of where the script is executed
+    cwd = os.getcwd()
+
+    #Check whether the current working directory exists
+    grd.Filesystem.PathExist(cwd)
+
+    #Check whether the workplace folder exists    
     grd.Filesystem.PathExist(config.Workplace)
 
-#     #Loop-over the workflows
-    for flow in config.Workflow:
-        pathToFlow = helper.FullFilePath(config.Workplace,flow)
-        helper.CreateFolder(pathToFlow)
-        grd.Filesystem.PathExist(pathToFlow)
+    # Only create the flow when the script is executed from the workspace directory
+    if cwd == config.Workplace:
+        #Loop-over the workflows
+        for flow in config.Workflow:
+            pathToFlow = helper.FullFilePath(config.Workplace, flow)
+            helper.CreateFolder(pathToFlow)
+            grd.Filesystem.PathExist(pathToFlow)
+            click.echo(f'Flow created: {pathToFlow}')
+    else:
+        click.echo(f'Script command should be called from the workspace directory: {config.Workplace}')
 
 def Rename(config):
+    '''Method to rename files within the baseflow directory
+    
+    Args:
+        config (Config): Config data object
+    '''
+
     # Get the current working directory of where the script is executed
     cwd = os.getcwd()
 
@@ -29,24 +59,35 @@ def Rename(config):
 
     # Obtain the name of the base directory of the current working directory
     basename = os.path.basename(cwd)
+    
+    # Obtain the path to the base flow project
+    pathToBaseflowProject = helper.FullFilePath(config.Workplace, config.Baseflow, basename)
+    # Check whether the the path to the base flow project exists
+    grd.Filesystem.PathExist(pathToBaseflowProject)
 
-#     # Loop-ver the workflows and add an project directory to each flow
-    for flow in config.Workflow:
-#         # Obtain the path to the project flow
-        pathToFlowProject = helper.FullFilePath(config.Workplace,flow,basename)
+    # Only rename filenames within a baseflow project directory
+    if cwd == pathToBaseflowProject:
+        # Loop-ver the workflows and add an project directory to each flow
+        for flow in config.Workflow:
+            # Obtain the path to the project flow
+            pathToFlowProject = helper.FullFilePath(config.Workplace,flow,basename)
 
-        helper.CreateFolder(pathToFlowProject)
+            # Check if folder exists ...
+            if not grd.Filesystem.IsPath(pathToFlowProject):
+                helper.CreateFolder(pathToFlowProject)
 
-        grd.Filesystem.PathExist(pathToFlowProject)
+                grd.Filesystem.PathExist(pathToFlowProject)
 
-        print(f"Added folder: {pathToFlowProject}")
+                click.echo(f'Project created: {pathToFlowProject}')
 
-    print('\r\n')
+        print('\r\n')
+    else:
+        click.echo(f'Script command should be called from the baseflow directory: {pathToBaseflowProject}')
 
     flow = ''
     counter = 0
 
-#     # Loop over every word of the flow name directory
+    # Loop over every word of the flow name directory
     for i in basename.split(' '):
         # Append the individual words to an '_'
         flow += f'{i}_'
@@ -73,24 +114,32 @@ def Rename(config):
         # Obtain the absolute path to the new picture name
         pathToNewPicture = os.path.join(cwd, newName)
 
-        # Rename the picture file
-        os.rename(pathToPicture, pathToNewPicture)
+        # Only rename the changed files
+        if not pathToNewPicture == pathToPicture:
+            # Rename the picture file
+            os.rename(pathToPicture, pathToNewPicture)
 
-        print(f"Renaming: {picture} -> {newName}")
+            click.echo(f"Renaming: {picture} -> {newName}")
 
-        # Check whether the new picture file exists after renaming
-        grd.Filesystem.PathExist(pathToNewPicture)
+            # Check whether the new picture file exists after renaming
+            grd.Filesystem.PathExist(pathToNewPicture)
 
-        counter += 1
-    
-    print(f"Renamed files: {counter}")
+            counter += 1
 
+    click.echo(f"Renamed files: {counter}")
+
+def Version():
+    '''Method which prints the current script version'''
+
+    click.echo(f'Script version: {pb.__version__}')
+   
 @click.command()
 @click.option('--create', '-c', is_flag=True, help='Create workspace directory')
 @click.option('--rename', '-r', is_flag=True, help='Rename the files in the main flow directory')
 @click.option('--location', '-l', is_flag=True, help='Config file location')
+@click.option('--version', '-v', is_flag=True, help='Script version')
 # @pass_config
-def main(create,rename, location):
+def main(create,rename, location, version):
     """Console script for picturebot."""
     
     pathToConfig = helper.FullFilePath("config.json")
@@ -109,8 +158,10 @@ def main(create,rename, location):
         Rename(config)
     elif location:
         Location(pathToConfig)
+    elif version:
+        Version()
     else:
         click.echo('No arguments were passed, please enter --help for more information')
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    main()

--- a/picturebot/cli.py
+++ b/picturebot/cli.py
@@ -138,7 +138,6 @@ def Version():
 @click.option('--rename', '-r', is_flag=True, help='Rename the files in the main flow directory')
 @click.option('--location', '-l', is_flag=True, help='Config file location')
 @click.option('--version', '-v', is_flag=True, help='Script version')
-# @pass_config
 def main(create,rename, location, version):
     """Console script for picturebot."""
     
@@ -164,4 +163,4 @@ def main(create,rename, location, version):
         click.echo('No arguments were passed, please enter --help for more information')
 
 if __name__ == "__main__":
-    main()
+    main() # pragma: no cover

--- a/picturebot/config.json
+++ b/picturebot/config.json
@@ -1,10 +1,11 @@
 {
-    "workplace": "D:\\Programs\\PictureBot\\TEST",
+    "workplace": "D:\\PicTest",
     "workflow" : [
-        "Files",
-        "Modded",
-        "Natural",
+        "RAW",
+        "Selected",
+        "Edited",
+        "Affinity",
         "Instagram"
     ],
-    "baseflow" : "Natural"
+    "baseflow" : "RAW"
 }

--- a/picturebot/helper.py
+++ b/picturebot/helper.py
@@ -41,4 +41,3 @@ def CreateFolder(path):
 
         # Check whether creation was successfull
         grd.Filesystem.PathExist(path)
-        print(f'Created flow: {path}')

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite='tests',
     tests_require=requirements,
     url='https://github.com/Tomekske/picturebot',
-    version='0.0.3',
+    version='0.0.4',
     zip_safe=False,
 )


### PR DESCRIPTION
- A workspace can only be created within the declared workspace directory specified within the config file
- Files can only be renamed within the baseflow directory
- Only changed files names are listed in the output
- Only missing project flows are getting added when renaming files
- Added command to check the script version