### PR TITLE
Add index to hashed files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,3 +70,9 @@ History
 
 * Improvement: Use guard method to check whether the cwd is within the correct directory
 * Open the edited folder from within the selection folder
+
+0.0.11 (2019-09-18)
+-------------------
+
+* Hash files are sorted by creation date
+* Updated: Renamed files are sorted by creation date instead of modification date

--- a/picturebot/__init__.py
+++ b/picturebot/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Tomek Joostens"""
 __email__ = 'joostenstomek@gmail.com'
-__version__ = '0.0.10'
+__version__ = '0.0.11'

--- a/picturebot/cli.py
+++ b/picturebot/cli.py
@@ -108,7 +108,7 @@ def Rename(config):
     # Obtain the original picture name within a flow directory
     pictures = os.listdir(cwd)
     # sort by date
-    pictures.sort(key=os.path.getmtime)
+    pictures.sort(key=os.path.getctime)
 
     # Loop over every picture withing the flow directory
     for index, picture in enumerate(pictures, 1):
@@ -282,9 +282,12 @@ def Hash():
     # Obtain the original picture name within a flow directory
     pictures = os.listdir(cwd)
 
+    # sort by date
+    pictures.sort(key=os.path.getctime)
+
     # Append files with an extension to a new list
     for picture in pictures:
-        
+ 
         if '.' in picture:
             files.append(picture)
 
@@ -302,7 +305,7 @@ def Hash():
         md5Hash = helper.HashFileMd5(pathToPicture)
         
         # Get the new name for the picture
-        newName = f"file_{md5Hash}.{extension}"
+        newName = f"PB_{index}_{md5Hash}_{index}.{extension}"
 
         # Obtain the absolute path to the new picture name
         pathToNewPicture = os.path.join(cwd, newName)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite='tests',
     tests_require=requirements,
     url='https://github.com/Tomekske/picturebot',
-    version='0.0.10',
+    version='0.0.11',
     zip_safe=False,
 )


### PR DESCRIPTION
- Hash files are sorted by creation date
- Updated: Renamed files are sorted by creation date instead of modification date